### PR TITLE
added ManagedEsent Nuget package instead of libs

### DIFF
--- a/src/nsimpleeventstore/nsimpleeventstore/nsimpleeventstore.csproj
+++ b/src/nsimpleeventstore/nsimpleeventstore/nsimpleeventstore.csproj
@@ -14,20 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Database.Collections.Generic" Version="2.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
       <PackageReference Include="NSimpleEventStore.Contract" Version="2.1.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Esent.Collections">
-        <HintPath>..\..\..\lib\Esent.Collections.dll</HintPath>
-      </Reference>
-      <Reference Include="Esent.Interop">
-        <HintPath>..\..\..\lib\Esent.Interop.dll</HintPath>
-      </Reference>
-      <Reference Include="Esent.Isam">
-        <HintPath>..\..\..\lib\Esent.Isam.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Microsoft has a released a version of ManagedEsent (https://github.com/microsoft/ManagedEsent) for .NETStandard 2.0 and published on NuGet (https://www.nuget.org/packages/Microsoft.Database.Collections.Generic/). It is better to use this NuGet packages instead of referencing the custom DLLs directly.